### PR TITLE
build: modernize Python support and decouple streaming env from PsychoPy & VR deps

### DIFF
--- a/.github/actions/setup-conda-env/action.yml
+++ b/.github/actions/setup-conda-env/action.yml
@@ -1,0 +1,32 @@
+name: Set up conda env
+description: >
+  Install Miniconda and create/activate an EEG-ExPy conda environment from
+  the given env yml. Shared by the Test and Typecheck jobs so the two
+  don't drift apart. Environment name is not set in the yml files so local
+  installs can use any name they like.
+
+inputs:
+  environment-file:
+    required: true
+    description: Path to the conda environment yml file to install from.
+  activate-environment:
+    required: true
+    description: Name to give the created environment.
+  python-version:
+    required: false
+    description: >
+      Python version to pin (e.g. '3.8'). Overrides the version conda would
+      otherwise resolve from the environment file's constraints. When omitted,
+      conda resolves freely within the environment file's range.
+
+runs:
+  using: composite
+  steps:
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        environment-file: ${{ inputs.environment-file }}
+        activate-environment: ${{ inputs.activate-environment }}
+        python-version: ${{ inputs.python-version }}
+        auto-activate-base: false
+        channels: conda-forge
+        miniconda-version: "latest"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.10'
         
     - name: Install dependencies
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/dev/')
+      if: github.ref == 'refs/heads/master'  # TODO: Deploy seperate develop-version of docs?
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: doc/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,29 +9,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0   
-        
-    - name: Set up Python
-      uses: actions/setup-python@v4
+        fetch-depth: 0
+
+    - name: Set up conda env
+      uses: ./.github/actions/setup-conda-env
       with:
-        python-version: '3.10'
-        
-    - name: Install dependencies
-      run: |
-        make install-deps-apt
-        python -m pip install --upgrade pip wheel
-        python -m pip install attrdict
-
-        make install-deps-wxpython
-        
-    - name: Build project
-      run: |
-        make install-docs-build-dependencies
-
+        environment-file: environments/eeg-expy-docsbuild.yml
+        activate-environment: eeg-expy-docsbuild
 
     - name: Get list of changed files
       id: changes
@@ -40,7 +31,6 @@ jobs:
         git diff --name-only origin/master...HEAD > changed_files.txt
         cat changed_files.txt
 
-
     - name: Determine build mode
       id: mode
       run: |
@@ -48,12 +38,12 @@ jobs:
           echo "FULL_BUILD=true" >> $GITHUB_ENV
           echo "Detected non-example file change. Full build triggered."
         else
-          CHANGED_EXAMPLES=$(grep '^examples/.*\.py$' changed_files.txt | paste -sd '|' -)
+          # || true prevents grep's exit code 1 (no matches) from aborting the step
+          CHANGED_EXAMPLES=$(grep '^examples/.*\.py$' changed_files.txt | paste -sd '|' - || true)
           echo "FULL_BUILD=false" >> $GITHUB_ENV
           echo "CHANGED_EXAMPLES=$CHANGED_EXAMPLES" >> $GITHUB_ENV
           echo "Changed examples: $CHANGED_EXAMPLES"
         fi
-
 
     - name: Cache built documentation
       id: cache-docs
@@ -65,15 +55,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-sphinx-
 
-
     - name: Build docs
-      run: |
-        make docs
+      run: make docs
 
-        
     - name: Deploy Docs
       uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/master'  # TODO: Deploy seperate develop-version of docs?
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/dev/')
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: doc/_build/html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,33 @@ jobs:
     defaults:
       run:
         shell: bash -el {0}
+    continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-22.04', windows-latest, macOS-latest]
-        python_version: ['3.8']
+        os: [ubuntu-22.04, windows-latest, macOS-latest]
+        python_version: ['3.10']
+        env_file: [environments/eeg-expy-full.yml]
+        env_name: [eeg-expy-full]
         include:
-          # PsychoPy currently restricted to <= 3.10
+          # Experimental Full Build: Catch regressions on 3.11 early
           - os: ubuntu-22.04
-            python_version: '3.10'
+            python_version: '3.11'
+            experimental: true
+            env_file: environments/eeg-expy-full.yml
+            env_name: eeg-expy-full
+
+          # Experimental Streaming Builds: Verify acquisition/analysis on 3.12+
+          - os: ubuntu-22.04
+            python_version: '3.12'
+            experimental: true
+            env_file: environments/eeg-expy-streaming.yml
+            env_name: eeg-expy-streaming
+          - os: ubuntu-22.04
+            python_version: '3.13'
+            experimental: true
+            env_file: environments/eeg-expy-streaming.yml
+            env_name: eeg-expy-streaming
 
     steps:
     - uses: actions/checkout@v2
@@ -32,10 +50,10 @@ jobs:
     - name: Install conda
       uses: conda-incubator/setup-miniconda@v3
       with:
-        environment-file: environments/eeg-expy-full.yml
+        environment-file: ${{ matrix.env_file || 'environments/eeg-expy-full.yml' }}
         auto-activate-base: false
         python-version: ${{ matrix.python_version }}
-        activate-environment: eeg-expy-full
+        activate-environment: ${{ matrix.env_name || 'eeg-expy-full' }}
         channels: conda-forge
         miniconda-version: "latest"
 
@@ -58,7 +76,7 @@ jobs:
           Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> xvfb.log &
           export DISPLAY=:0
         fi
-        make test PYTEST_ARGS="--ignore=tests/test_run_experiments.py"
+        make test
 
 
   typecheck:
@@ -71,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-22.04']
-        python_version: [3.9]
+        python_version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,22 +47,13 @@ jobs:
       if: "startsWith(runner.os, 'Linux')"
       run: |
         make install-deps-apt
-    - name: Install conda
-      uses: conda-incubator/setup-miniconda@v3
+    - name: Set up conda env
+      uses: ./.github/actions/setup-conda-env
       with:
-        environment-file: ${{ matrix.env_file || 'environments/eeg-expy-full.yml' }}
-        auto-activate-base: false
+        environment-file: ${{ matrix.env_file }}
+        activate-environment: ${{ matrix.env_name }}
         python-version: ${{ matrix.python_version }}
-        activate-environment: ${{ matrix.env_name || 'eeg-expy-full' }}
-        channels: conda-forge
-        miniconda-version: "latest"
-
-    - name: Fix PsychXR numpy dependency DLL issues (Windows only)
-      if: matrix.os == 'windows-latest'
-      run: |
-        conda install --force-reinstall numpy
-
-    - name: Run eegnb install test
+    - name: Run eeg-expy install test
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
           Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &> xvfb.log &
@@ -93,15 +84,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install conda
-      uses: conda-incubator/setup-miniconda@v3
+    - name: Set up conda env
+      uses: ./.github/actions/setup-conda-env
       with:
         environment-file: environments/eeg-expy-full.yml
-        auto-activate-base: false
-        python-version: ${{ matrix.python_version }}
         activate-environment: eeg-expy-full
-        channels: conda-forge
-        miniconda-version: "latest"
+        python-version: ${{ matrix.python_version }}
     - name: Typecheck
       run: |
         make typecheck

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+import importlib.util
+
+
+def _is_available(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+collect_ignore: list[str] = []
+
+if not _is_available("psychopy"):
+    collect_ignore += [
+        "eegnb/experiments",
+        "eegnb/devices/vr.py",
+    ]
+elif not _is_available("psychxr"):
+    collect_ignore += ["eegnb/devices/vr.py"]

--- a/eegnb/cli/introprompt.py
+++ b/eegnb/cli/introprompt.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from eegnb import generate_save_fn, DATA_DIR
 from eegnb.devices.eeg import EEG
-from .utils import run_experiment, get_exp_desc, experiments
+from .utils import run_experiment, get_exp_desc, get_experiments
 
 eegnb_sites = ['eegnb_examples', 'grifflab_dev', 'jadinlab_home']
 
@@ -87,6 +87,7 @@ def device_prompt() -> EEG:
 
 
 def exp_prompt(runorzip:str='run') -> str:
+    experiments = get_experiments()
     print("\nPlease select which experiment you would like to %s: \n" %runorzip)
     print(
         "\n".join(

--- a/eegnb/cli/utils.py
+++ b/eegnb/cli/utils.py
@@ -1,38 +1,42 @@
 
-#change the pref libraty to PTB and set the latency mode to high precision
-from psychopy import prefs
-prefs.hardware['audioLib'] = 'PTB'
-prefs.hardware['audioLatencyMode'] = 3
+try:
+    #change the pref libraty to PTB and set the latency mode to high precision
+    from psychopy import prefs
+    prefs.hardware['audioLib'] = 'PTB'
+    prefs.hardware['audioLatencyMode'] = 3
+except ImportError:
+    pass
 
 
 from eegnb.devices.eeg import EEG
-
-from eegnb.experiments import VisualN170, Experiment
-from eegnb.experiments import VisualP300
-from eegnb.experiments import VisualSSVEP
-from eegnb.experiments import AuditoryOddball
-from eegnb.experiments.visual_cueing import cueing
-from eegnb.experiments.visual_codeprose import codeprose
-from eegnb.experiments.auditory_oddball import diaconescu
-from eegnb.experiments.auditory_ssaep import ssaep, ssaep_onefreq
 from typing import Optional
 
+def get_experiments():
+    from eegnb.experiments import VisualN170, Experiment
+    from eegnb.experiments import VisualP300
+    from eegnb.experiments import VisualSSVEP
+    from eegnb.experiments import AuditoryOddball
+    from eegnb.experiments.visual_cueing import cueing
+    from eegnb.experiments.visual_codeprose import codeprose
+    from eegnb.experiments.auditory_oddball import diaconescu
+    from eegnb.experiments.auditory_ssaep import ssaep, ssaep_onefreq
 
-# New Experiment Class structure has a different initilization, to be noted
-experiments = {
-    "visual-N170": VisualN170(),
-    "visual-P300": VisualP300(),
-    "visual-SSVEP": VisualSSVEP(),
-    "visual-cue": cueing,
-    "visual-codeprose": codeprose,
-    "auditory-SSAEP orig": ssaep,
-    "auditory-SSAEP onefreq": ssaep_onefreq,
-    "auditory-oddball orig": AuditoryOddball(),
-    "auditory-oddball diaconescu": diaconescu,
-}
+    # New Experiment Class structure has a different initilization, to be noted
+    return {
+        "visual-N170": VisualN170,
+        "visual-P300": VisualP300,
+        "visual-SSVEP": VisualSSVEP,
+        "visual-cue": cueing,
+        "visual-codeprose": codeprose,
+        "auditory-SSAEP orig": ssaep,
+        "auditory-SSAEP onefreq": ssaep_onefreq,
+        "auditory-oddball orig": AuditoryOddball,
+        "auditory-oddball diaconescu": diaconescu,
+    }
 
 
 def get_exp_desc(exp: str):
+    experiments = get_experiments()
     if exp in experiments:
         module = experiments[exp]
         if hasattr(module, "__title__"):
@@ -43,17 +47,24 @@ def get_exp_desc(exp: str):
 def run_experiment(
     experiment: str, eeg_device: EEG, record_duration: Optional[float] = None, save_fn=None
 ):
+    experiments = get_experiments()
     if experiment in experiments:
-        module = experiments[experiment]
+        exp_item = experiments[experiment]
+
+        from eegnb.experiments import Experiment
 
         # Condition added for different run types of old and new experiment class structure
-        if isinstance(module, Experiment.BaseExperiment):
+        # If it's a class (BaseExperiment subclass), instantiate it
+        if isinstance(exp_item, type) and issubclass(exp_item, Experiment.BaseExperiment):
+            # Concrete subclasses supply defaults for BaseExperiment's required args; mypy can't see which subclass.
+            module = exp_item()  # type: ignore[call-arg]
             module.duration = record_duration
             module.eeg = eeg_device
             module.save_fn = save_fn
             module.run()
         else:
-            module.present(duration=record_duration, eeg=eeg_device, save_fn=save_fn)  # type: ignore
+            # Otherwise it's an old-style module
+            exp_item.present(duration=record_duration, eeg=eeg_device, save_fn=save_fn)  # type: ignore
     else:
         print("\nError: Unknown experiment '{}'".format(experiment))
         print("\nExperiment can be one of:")

--- a/eegnb/cli/utils.py
+++ b/eegnb/cli/utils.py
@@ -57,11 +57,11 @@ def run_experiment(
         # If it's a class (BaseExperiment subclass), instantiate it
         if isinstance(exp_item, type) and issubclass(exp_item, Experiment.BaseExperiment):
             # Concrete subclasses supply defaults for BaseExperiment's required args; mypy can't see which subclass.
-            module = exp_item()  # type: ignore[call-arg]
-            module.duration = record_duration
-            module.eeg = eeg_device
-            module.save_fn = save_fn
-            module.run()
+            exp_instance = exp_item()  # type: ignore[call-arg]
+            exp_instance.duration = record_duration
+            exp_instance.eeg = eeg_device
+            exp_instance.save_fn = save_fn
+            exp_instance.run()
         else:
             # Otherwise it's an old-style module
             exp_item.present(duration=record_duration, eeg=eeg_device, save_fn=save_fn)  # type: ignore

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -20,7 +20,10 @@ from pylsl import StreamInfo, StreamOutlet, StreamInlet, resolve_byprop
 
 from serial import Serial, EIGHTBITS, PARITY_NONE, STOPBITS_ONE
 
-import pyxid2
+try:
+    import pyxid2
+except Exception:
+    pyxid2 = None
 
 from eegnb.devices.utils import (
     get_openbci_usb,

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -22,7 +22,10 @@ from serial import Serial, EIGHTBITS, PARITY_NONE, STOPBITS_ONE
 
 try:
     import pyxid2
-except ImportError:
+except (ImportError, OSError):
+    # OSError covers pyxid2 being installed but its native FTDI dependency
+    # (libftd2xx.so / ftd2xx.dll) being absent — common on Linux CI where
+    # the proprietary FTDI driver isn't installed.
     from eegnb.utils.missing import missing_module
     pyxid2 = missing_module(
         "pyxid2",

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -22,8 +22,13 @@ from serial import Serial, EIGHTBITS, PARITY_NONE, STOPBITS_ONE
 
 try:
     import pyxid2
-except Exception:
-    pyxid2 = None
+except ImportError:
+    from eegnb.utils.missing import missing_module
+    pyxid2 = missing_module(
+        "pyxid2",
+        "The Cedrus XID backend (NIRSport2 and other Cedrus stimulus-marker devices)",
+        "xid",
+    )
 
 from eegnb.devices.utils import (
     get_openbci_usb,

--- a/eegnb/devices/eeg.py
+++ b/eegnb/devices/eeg.py
@@ -20,13 +20,11 @@ from pylsl import StreamInfo, StreamOutlet, StreamInlet, resolve_byprop
 
 from serial import Serial, EIGHTBITS, PARITY_NONE, STOPBITS_ONE
 
+from eegnb.utils.missing import missing_module
+
 try:
     import pyxid2
 except (ImportError, OSError):
-    # OSError covers pyxid2 being installed but its native FTDI dependency
-    # (libftd2xx.so / ftd2xx.dll) being absent — common on Linux CI where
-    # the proprietary FTDI driver isn't installed.
-    from eegnb.utils.missing import missing_module
     pyxid2 = missing_module(
         "pyxid2",
         "The Cedrus XID backend (NIRSport2 and other Cedrus stimulus-marker devices)",

--- a/eegnb/devices/vr.py
+++ b/eegnb/devices/vr.py
@@ -12,6 +12,7 @@ class VR(Rift):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.libovr_to_wallclock_offset = None
+        self.timing_data = []
 
     def compute_optical_axis_offsets(self):
         """
@@ -89,8 +90,6 @@ class VR(Rift):
                 f"res={self.displayResolution}  eye_buf={self.size}"
             )
 
-            if not hasattr(self, 'timing_data'):
-                self.timing_data = []
             self.timing_data.insert(0, ['# ipd_mm', ipd_mm, 'ppd', ppd, f'ppd_h={ppd_h:.1f} ppd_v={ppd_v:.1f}'])
 
             return ppd, ipd_mm
@@ -117,9 +116,6 @@ class VR(Rift):
                 time_to_vsync_s = stat.timeToVsync
         except Exception:
             pass
-        
-        if not hasattr(self, 'timing_data'):
-            self.timing_data = []
             
         self.timing_data.append([
             trial_idx, software_time,

--- a/eegnb/devices/vr.py
+++ b/eegnb/devices/vr.py
@@ -1,0 +1,148 @@
+import logging
+import numpy as np
+from time import time
+from psychopy.visual.rift import Rift
+
+class VR(Rift):
+    """
+    Extended VR class for HMDs, providing built-in methods for
+    stereoscopic rendering math, precise hardware clock synchronization,
+    and per-trial compositor telemetry buffering.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.libovr_to_wallclock_offset = None
+
+    def compute_optical_axis_offsets(self):
+        """
+        NDC x offsets placing content on each lens's optical axis:
+        ndc_x = (LeftTan - RightTan) / (LeftTan + RightTan).
+        """
+        try:
+            import psychxr.drivers.libovr as libovr
+            # fov = [UpTan, DownTan, LeftTan, RightTan]
+            left_fov, _, _ = libovr.getEyeRenderFov(libovr.EYE_LEFT)
+            right_fov, _, _ = libovr.getEyeRenderFov(libovr.EYE_RIGHT)
+            left_L, left_R = float(left_fov[2]), float(left_fov[3])
+            right_L, right_R = float(right_fov[2]), float(right_fov[3])
+            return ((left_L - left_R) / (left_L + left_R),
+                    (right_L - right_R) / (right_L + right_R))
+        except Exception as e:
+            logging.warning(f"[VR] Failed to compute optical axis offsets: {e}")
+            return (0.0, 0.0)
+
+    def sync_vr_clock(self):
+        """
+        Calculates Wall-clock <-> LibOVR clock offset. LibOVR timestamps are on a QPC-based
+        clock with arbitrary zero; time.time() is Unix epoch. Sample paired calls in a 
+        tight bracket and keep the tightest, so analysis can convert LibOVR times to wall-clock.
+        """
+        if self.libovr_to_wallclock_offset is not None:
+            return self.libovr_to_wallclock_offset
+
+        try:
+            from psychxr.drivers.libovr import timeInSeconds
+            best_bracket = None
+            best_offset = None
+            for _ in range(21):
+                t0 = time()
+                lovr = timeInSeconds()
+                t1 = time()
+                bracket = t1 - t0
+                offset = 0.5 * (t0 + t1) - lovr
+                if best_bracket is None or bracket < best_bracket:
+                    best_bracket = bracket
+                    best_offset = offset
+            
+            logging.info(
+                f"[VR] clock offset (wall - libovr) = "
+                f"{best_offset:.6f}s  (tightest bracket = {best_bracket*1e3:.3f}ms)"
+            )
+            
+            self.libovr_to_wallclock_offset = best_offset
+            return best_offset
+        except Exception as e:
+            logging.warning(f"[VR] LibOVR clock sync failed: {e}")
+            return None
+
+    def log_display_info(self):
+        """
+        Reads IPD, PPD, and display resolution from the LibOVR session and logs
+        them to the telemetry sidecar as header comment rows.
+        Returns (ppd, ipd_mm) for use in stimulus sizing.
+        """
+        try:
+            ppta = self.pixelsPerTanAngleAtCenter
+            ppd_h = np.mean([p[0] for p in ppta]) * (np.pi / 180.0)
+            ppd_v = np.mean([p[1] for p in ppta]) * (np.pi / 180.0)
+            ppd = int(round(min(ppd_h, ppd_v)))
+
+            eye_to_nose = self.eyeToNoseDistance
+            ipd_mm = (eye_to_nose[0] + eye_to_nose[1]) * 1000.0
+
+            logging.info(
+                f"[VR] IPD={ipd_mm:.1f}mm  ppd={ppd} (h={ppd_h:.1f} v={ppd_v:.1f})  "
+                f"res={self.displayResolution}  eye_buf={self.size}"
+            )
+
+            if not hasattr(self, 'timing_data'):
+                self.timing_data = []
+            self.timing_data.insert(0, ['# ipd_mm', ipd_mm, 'ppd', ppd, f'ppd_h={ppd_h:.1f} ppd_v={ppd_v:.1f}'])
+
+            return ppd, ipd_mm
+        except Exception as e:
+            logging.warning(f"[VR] Failed to read display info: {e}")
+            return None, None
+
+    def log_telemetry(self, trial_idx, software_time):
+        """Extracts native LibOVR performance stats and buffers them in memory."""
+        submitted_frame_index = None
+        app_frame_index = None
+        app_m2p_s = None
+        comp_latency_s = None
+        time_to_vsync_s = None
+        
+        try:
+            submitted_frame_index = self._frameIndex - 1
+            perf = getattr(self, '_perfStats', None)
+            if perf is not None and perf.frameStatsCount > 0:
+                stat = perf.frameStats[0]
+                app_frame_index = stat.appFrameIndex
+                app_m2p_s = stat.appMotionToPhotonLatency
+                comp_latency_s = stat.compositorLatency
+                time_to_vsync_s = stat.timeToVsync
+        except Exception:
+            pass
+        
+        if not hasattr(self, 'timing_data'):
+            self.timing_data = []
+            
+        self.timing_data.append([
+            trial_idx, software_time,
+            submitted_frame_index, app_frame_index,
+            app_m2p_s, comp_latency_s, time_to_vsync_s
+        ])
+
+    def save_telemetry(self, save_fn):
+        """Saves memory-buffered VR timing telemetry to a CSV sidecar."""
+        timing_data = getattr(self, 'timing_data', [])
+        if not timing_data:
+            return
+            
+        import csv
+        timing_path = save_fn.with_name(save_fn.stem + '_timing.csv') if save_fn else 'vr_timing.csv'
+        with open(timing_path, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow([
+                'trial_idx', 'software_time',
+                'submitted_frame_index', 'app_frame_index',
+                'app_motion_to_photon_latency_s', 'compositor_latency_s',
+                'time_to_vsync_s'
+            ])
+            
+            # Log the clock offset if calculated
+            if self.libovr_to_wallclock_offset is not None:
+                 writer.writerow(['# libovr_to_wallclock_offset_s', self.libovr_to_wallclock_offset, 'bracket_ms', 0])
+                 
+            writer.writerows(timing_data)
+        print(f"  Saved VR timing telemetry to {timing_path}")

--- a/eegnb/devices/vr.py
+++ b/eegnb/devices/vr.py
@@ -1,4 +1,5 @@
 import logging
+import csv
 import numpy as np
 from time import time
 from psychopy.visual.rift import Rift
@@ -12,6 +13,7 @@ class VR(Rift):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.libovr_to_wallclock_offset = None
+        self.libovr_to_wallclock_bracket = None
         self.timing_data = []
 
     def compute_optical_axis_offsets(self):
@@ -65,6 +67,7 @@ class VR(Rift):
             )
             
             self.libovr_to_wallclock_offset = best_offset
+            self.libovr_to_wallclock_bracket = best_bracket
             return best_offset
         except Exception as e:
             logging.warning(f"[VR] LibOVR clock sync failed: {e}")
@@ -125,11 +128,9 @@ class VR(Rift):
 
     def save_telemetry(self, save_fn):
         """Saves memory-buffered VR timing telemetry to a CSV sidecar."""
-        timing_data = getattr(self, 'timing_data', [])
-        if not timing_data:
+        if not self.timing_data:
             return
             
-        import csv
         timing_path = save_fn.with_name(save_fn.stem + '_timing.csv') if save_fn else 'vr_timing.csv'
         with open(timing_path, 'w', newline='') as f:
             writer = csv.writer(f)
@@ -142,7 +143,7 @@ class VR(Rift):
             
             # Log the clock offset if calculated
             if self.libovr_to_wallclock_offset is not None:
-                 writer.writerow(['# libovr_to_wallclock_offset_s', self.libovr_to_wallclock_offset, 'bracket_ms', 0])
+                 writer.writerow(['# libovr_to_wallclock_offset_s', self.libovr_to_wallclock_offset, 'bracket_ms', self.libovr_to_wallclock_bracket * 1000])
                  
-            writer.writerows(timing_data)
+            writer.writerows(self.timing_data)
         print(f"  Saved VR timing telemetry to {timing_path}")

--- a/eegnb/devices/vr.py
+++ b/eegnb/devices/vr.py
@@ -127,11 +127,12 @@ class VR(Rift):
         ])
 
     def save_telemetry(self, save_fn):
-        """Saves memory-buffered VR timing telemetry to a CSV sidecar."""
-        if not self.timing_data:
+        """Saves memory-buffered VR timing telemetry to a CSV sidecar.
+        """
+        if save_fn is None:
             return
-            
-        timing_path = save_fn.with_name(save_fn.stem + '_timing.csv') if save_fn else 'vr_timing.csv'
+
+        timing_path = save_fn.with_name(save_fn.stem + '_timing.csv')
         with open(timing_path, 'w', newline='') as f:
             writer = csv.writer(f)
             writer.writerow([
@@ -140,10 +141,9 @@ class VR(Rift):
                 'app_motion_to_photon_latency_s', 'compositor_latency_s',
                 'time_to_vsync_s'
             ])
-            
-            # Log the clock offset if calculated
+
             if self.libovr_to_wallclock_offset is not None:
-                 writer.writerow(['# libovr_to_wallclock_offset_s', self.libovr_to_wallclock_offset, 'bracket_ms', self.libovr_to_wallclock_bracket * 1000])
-                 
+                writer.writerow(['# libovr_to_wallclock_offset_s', self.libovr_to_wallclock_offset, 'bracket_ms', self.libovr_to_wallclock_bracket * 1000])
+
             writer.writerows(self.timing_data)
         print(f"  Saved VR timing telemetry to {timing_path}")

--- a/eegnb/devices/vr.py
+++ b/eegnb/devices/vr.py
@@ -15,8 +15,12 @@ class VR(Rift):
 
     def compute_optical_axis_offsets(self):
         """
-        NDC x offsets placing content on each lens's optical axis:
-        ndc_x = (LeftTan - RightTan) / (LeftTan + RightTan).
+        Computes the Normalized Device Coordinates (NDC) horizontal (x) offset 
+        needed to center content directly in front of each eye's physical lens.
+        
+        Because VR headsets use asymmetric lenses (the screen extends further 
+        to the outside of the eye than the inside), the mathematical center of 
+        the screen (NDC 0,0) does not align with the user's optical axis.
         """
         try:
             import psychxr.drivers.libovr as libovr

--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -62,12 +62,9 @@ class BaseExperiment(ABC):
         self.stereoscopic = stereoscopic
         if use_vr:
             # VR interface accessible by specific experiment classes for customizing and using controllers.
-            # VR extends psychopy's VR with clock sync, per-trial telemetry buffering, and telemetry CSV saving.
             self.vr: VR = VR(monoscopic=not stereoscopic, headLocked=True)
 
-        # Shift the display so it aligns perfectly with the center of each eye. 
-        # VR headsets have angled screens, so if we draw everything strictly at 
-        # the center of the display (0,0), it makes the user feel cross-eyed.
+        # Shift the display so it aligns perfectly with the center of each eye.
         if use_vr and stereoscopic:
             self.left_eye_x_pos, self.right_eye_x_pos = self.vr.compute_optical_axis_offsets()
         else:
@@ -334,8 +331,6 @@ class BaseExperiment(ABC):
                 return False
 
         return True
-
-
 
     def run(self, instructions=True):
         """ Run the experiment """

--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -11,15 +11,16 @@ obj.run()
 from abc import abstractmethod, ABC
 from typing import Callable
 from eegnb.devices.eeg import EEG
-from psychopy import prefs
-from psychopy.visual.rift import Rift
+from eegnb.devices.vr import VR
+from psychopy import prefs, visual, event, core
 
+import gc
 from time import time
 import random
+import json
 
 import numpy as np
 from pandas import DataFrame
-from psychopy import visual, event
 
 from eegnb import generate_save_fn
 
@@ -61,11 +62,14 @@ class BaseExperiment(ABC):
         self.stereoscopic = stereoscopic
         if use_vr:
             # VR interface accessible by specific experiment classes for customizing and using controllers.
-            self.rift: Rift = visual.Rift(monoscopic=not stereoscopic, headLocked=True)
-        # eye for presentation
-        if stereoscopic:
-            self.left_eye_x_pos = 0.2
-            self.right_eye_x_pos = -0.2
+            # VR extends psychopy's VR with clock sync, per-trial telemetry buffering, and telemetry CSV saving.
+            self.vr: VR = VR(monoscopic=not stereoscopic, headLocked=True)
+
+        # Shift content onto each lens's optical axis. VR HMDs use canted
+        # asymmetric frustums, so NDC (0,0) is off-axis and binocular content
+        # there forces inward vergence ("cross-eyed" feel).
+        if use_vr and stereoscopic:
+            self.left_eye_x_pos, self.right_eye_x_pos = self.vr.compute_optical_axis_offsets()
         else:
             self.left_eye_x_pos = 0
             self.right_eye_x_pos = 0
@@ -79,6 +83,7 @@ class BaseExperiment(ABC):
         # Setting up the trial and parameter list
         self.parameter = np.random.binomial(1, 0.5, self.n_trials)
         self.trials = DataFrame(dict(parameter=self.parameter, timestamp=np.zeros(self.n_trials)))
+
 
     @abstractmethod
     def load_stimulus(self):
@@ -113,10 +118,27 @@ class BaseExperiment(ABC):
         """
         self.window.flip()
 
+    def present_soa(self, idx: int):
+        """
+        Method called each frame during the SOA wait (stimulus-on period between trial transitions).
+
+        The default implementation just flips the buffer, which is fine for most uses.
+
+        Recommended for VR: override this to redraw the stimulus for trial `idx`. VR compositors
+        prefer a freshly drawn frame each submission; submitting only a flip leads
+        the compositor to treat frames as stale, which can drop to half-rate
+        reprojection and increase dropped/late frames. Overriding gives smoother
+        presentation and more accurate frame timing.
+
+        idx : Trial index of the most recently presented stimulus — same value that was
+              passed to the preceding present_stimulus call.
+        """
+        self.window.flip()
+
     def setup(self, instructions=True):
         # Setting up Graphics
         self.window = (
-            self.rift if self.use_vr
+            self.vr if self.use_vr
             else visual.Window(self.window_size, monitor="testMonitor", units="deg", 
                                screen = self.screen_num, fullscr=self.use_fullscr))
         
@@ -151,7 +173,8 @@ class BaseExperiment(ABC):
         """
 
         # Splitting instruction text into lines
-        self.instruction_text = self.instruction_text % self.duration
+        if '%s' in self.instruction_text:
+            self.instruction_text = self.instruction_text % self.duration
 
         # Disabling the cursor during display of instructions
         self.window.mouseVisible = False
@@ -215,13 +238,13 @@ class BaseExperiment(ABC):
         """
         trigger_squeezed = False
         if trigger:
-            for x in self.rift.getIndexTriggerValues(vr_controller):
+            for x in self.vr.getIndexTriggerValues(vr_controller):
                 if x > 0.0:
                     trigger_squeezed = True
 
         button_pressed = False
         if button is not None:
-            button_pressed, tsec = self.rift.getButtons([button], vr_controller, 'released')
+            button_pressed, tsec = self.vr.getButtons([button], vr_controller, 'released')
 
         if trigger_squeezed or button_pressed:
             return True
@@ -247,6 +270,7 @@ class BaseExperiment(ABC):
             tracking_state = self.window.getTrackingState()
             self.window.calcEyePoses(tracking_state.headPose.thePose)
             self.window.setDefaultView()
+
         present_stimulus()
 
     def _clear_user_input(self):
@@ -258,7 +282,7 @@ class BaseExperiment(ABC):
         Clears/resets input events from vr controllers
         """
         if self.use_vr:
-            self.rift.updateInputState()
+            self.vr.updateInputState()
         
     def _run_trial_loop(self, start_time, duration):
         """
@@ -302,6 +326,10 @@ class BaseExperiment(ABC):
                     # Stimulus presentation overwritten by specific experiment
                     self._draw(lambda: self.present_stimulus(current_trial))
                     rendering_trial = current_trial
+                else:
+                    # Keep submitting frames during SOA wait — VR compositor
+                    # drops to half-rate if we stall between reversals.
+                    self._draw(lambda: self.present_soa(current_trial))
             else:
                 self._draw(lambda: self.present_iti())
 
@@ -309,6 +337,49 @@ class BaseExperiment(ABC):
                 return False
 
         return True
+
+    def _enable_frame_tracking(self):
+        """Enable per-frame interval recording for dropped frame diagnostics."""
+        self.window.recordFrameIntervals = True
+        # Threshold for counting a frame as "dropped" — 50% over expected duration
+        expected_frame_dur = 1.0 / (self.window.displayRefreshRate if self.use_vr
+                                     else (self.window.getActualFrameRate() or 60))
+        self.window.refreshThreshold = expected_frame_dur * 1.5
+
+    def _report_frame_stats(self):
+        """Print frame timing summary and save intervals alongside recording."""
+        intervals = self.window.frameIntervals
+        if not intervals:
+            return
+
+        intervals_ms = [i * 1000 for i in intervals]
+        dropped = self.window.nDroppedFrames
+        total = len(intervals)
+        mean_ms = np.mean(intervals_ms)
+        std_ms = np.std(intervals_ms)
+        max_ms = max(intervals_ms)
+        refresh_rate_hz = int(np.round(
+            self.window.displayRefreshRate if self.use_vr
+            else (self.window.getActualFrameRate() or 0)
+        ))
+
+        print(f"\nFrame timing: {total} frames, {dropped} dropped ({dropped/total*100:.1f}%)")
+        print(f"  Refresh rate: {refresh_rate_hz} Hz")
+        print(f"  Mean: {mean_ms:.2f}ms  Std: {std_ms:.2f}ms  Max: {max_ms:.2f}ms")
+
+        if self.save_fn:
+            stats_path = self.save_fn.with_name(self.save_fn.stem + '_frame_stats.json')
+            with open(stats_path, 'w') as f:
+                json.dump({
+                    'display_refresh_rate_hz': refresh_rate_hz,
+                    'total_frames': total,
+                    'dropped_frames': dropped,
+                    'mean_ms': round(mean_ms, 3),
+                    'std_ms': round(std_ms, 3),
+                    'max_ms': round(max_ms, 3),
+                    'intervals_ms': [round(i, 3) for i in intervals_ms]
+                }, f, indent=2)
+            print(f"  Saved to {stats_path}")
 
     def run(self, instructions=True):
         """ Run the experiment """
@@ -323,11 +394,22 @@ class BaseExperiment(ABC):
                 self.eeg.start(self.save_fn, duration=self.duration + 5)
                 print("EEG Stream started")
 
+        self._enable_frame_tracking()
+
         # Record experiment until a key is pressed or duration has expired.
         record_start_time = time()
 
-        # Run the trial loop
-        self._run_trial_loop(record_start_time, self.duration)
+        core.rush(True)
+        gc.disable()
+        try:
+            if self.use_vr:        
+                self.vr.sync_vr_clock()
+            self._run_trial_loop(record_start_time, self.duration)
+        finally:
+            gc.enable()
+            core.rush(False)
+
+        self._report_frame_stats()
 
         # Clearing the screen for the next trial
         event.clearEvents()
@@ -336,10 +418,26 @@ class BaseExperiment(ABC):
         if self.eeg:
             self.eeg.stop()
 
+        if self.use_vr:
+            self.vr.save_telemetry(self.save_fn)
+
         # Closing the window
         self.window.close()
 
 
+
+    def push_vr_marker(self, marker, trial_idx):
+        """
+        Pushes the marker to EEG and delegates high-resolution LibOVR 
+        compositor stats to the VR hardware object.
+        """
+        software_time = time()
+        
+        if not self.eeg.push_sample(marker=marker):
+            return
+
+        if self.use_vr:
+            self.vr.log_telemetry(trial_idx, software_time)
 
     def send_triggers(self, marker):
         """Send timing triggers to recording device[s]"""
@@ -347,9 +445,7 @@ class BaseExperiment(ABC):
             timestamp = time()
             dev.push_sample(marker=marker, timestamp=timestamp)
 
-
     @property
     def name(self) -> str:
         """ This experiment's name """
         return self.exp_name
-

--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -65,9 +65,9 @@ class BaseExperiment(ABC):
             # VR extends psychopy's VR with clock sync, per-trial telemetry buffering, and telemetry CSV saving.
             self.vr: VR = VR(monoscopic=not stereoscopic, headLocked=True)
 
-        # Shift content onto each lens's optical axis. VR HMDs use canted
-        # asymmetric frustums, so NDC (0,0) is off-axis and binocular content
-        # there forces inward vergence ("cross-eyed" feel).
+        # Shift the display so it aligns perfectly with the center of each eye. 
+        # VR headsets have angled screens, so if we draw everything strictly at 
+        # the center of the display (0,0), it makes the user feel cross-eyed.
         if use_vr and stereoscopic:
             self.left_eye_x_pos, self.right_eye_x_pos = self.vr.compute_optical_axis_offsets()
         else:
@@ -83,7 +83,6 @@ class BaseExperiment(ABC):
         # Setting up the trial and parameter list
         self.parameter = np.random.binomial(1, 0.5, self.n_trials)
         self.trials = DataFrame(dict(parameter=self.parameter, timestamp=np.zeros(self.n_trials)))
-
 
     @abstractmethod
     def load_stimulus(self):
@@ -121,8 +120,6 @@ class BaseExperiment(ABC):
     def present_soa(self, idx: int):
         """
         Method called each frame during the SOA wait (stimulus-on period between trial transitions).
-
-        The default implementation just flips the buffer, which is fine for most uses.
 
         Recommended for VR: override this to redraw the stimulus for trial `idx`. VR compositors
         prefer a freshly drawn frame each submission; submitting only a flip leads
@@ -270,7 +267,6 @@ class BaseExperiment(ABC):
             tracking_state = self.window.getTrackingState()
             self.window.calcEyePoses(tracking_state.headPose.thePose)
             self.window.setDefaultView()
-
         present_stimulus()
 
     def _clear_user_input(self):
@@ -338,48 +334,7 @@ class BaseExperiment(ABC):
 
         return True
 
-    def _enable_frame_tracking(self):
-        """Enable per-frame interval recording for dropped frame diagnostics."""
-        self.window.recordFrameIntervals = True
-        # Threshold for counting a frame as "dropped" — 50% over expected duration
-        expected_frame_dur = 1.0 / (self.window.displayRefreshRate if self.use_vr
-                                     else (self.window.getActualFrameRate() or 60))
-        self.window.refreshThreshold = expected_frame_dur * 1.5
 
-    def _report_frame_stats(self):
-        """Print frame timing summary and save intervals alongside recording."""
-        intervals = self.window.frameIntervals
-        if not intervals:
-            return
-
-        intervals_ms = [i * 1000 for i in intervals]
-        dropped = self.window.nDroppedFrames
-        total = len(intervals)
-        mean_ms = np.mean(intervals_ms)
-        std_ms = np.std(intervals_ms)
-        max_ms = max(intervals_ms)
-        refresh_rate_hz = int(np.round(
-            self.window.displayRefreshRate if self.use_vr
-            else (self.window.getActualFrameRate() or 0)
-        ))
-
-        print(f"\nFrame timing: {total} frames, {dropped} dropped ({dropped/total*100:.1f}%)")
-        print(f"  Refresh rate: {refresh_rate_hz} Hz")
-        print(f"  Mean: {mean_ms:.2f}ms  Std: {std_ms:.2f}ms  Max: {max_ms:.2f}ms")
-
-        if self.save_fn:
-            stats_path = self.save_fn.with_name(self.save_fn.stem + '_frame_stats.json')
-            with open(stats_path, 'w') as f:
-                json.dump({
-                    'display_refresh_rate_hz': refresh_rate_hz,
-                    'total_frames': total,
-                    'dropped_frames': dropped,
-                    'mean_ms': round(mean_ms, 3),
-                    'std_ms': round(std_ms, 3),
-                    'max_ms': round(max_ms, 3),
-                    'intervals_ms': [round(i, 3) for i in intervals_ms]
-                }, f, indent=2)
-            print(f"  Saved to {stats_path}")
 
     def run(self, instructions=True):
         """ Run the experiment """
@@ -394,8 +349,6 @@ class BaseExperiment(ABC):
                 self.eeg.start(self.save_fn, duration=self.duration + 5)
                 print("EEG Stream started")
 
-        self._enable_frame_tracking()
-
         # Record experiment until a key is pressed or duration has expired.
         record_start_time = time()
 
@@ -409,8 +362,6 @@ class BaseExperiment(ABC):
             gc.enable()
             core.rush(False)
 
-        self._report_frame_stats()
-
         # Clearing the screen for the next trial
         event.clearEvents()
 
@@ -423,21 +374,6 @@ class BaseExperiment(ABC):
 
         # Closing the window
         self.window.close()
-
-
-
-    def push_vr_marker(self, marker, trial_idx):
-        """
-        Pushes the marker to EEG and delegates high-resolution LibOVR 
-        compositor stats to the VR hardware object.
-        """
-        software_time = time()
-        
-        if not self.eeg.push_sample(marker=marker):
-            return
-
-        if self.use_vr:
-            self.vr.log_telemetry(trial_idx, software_time)
 
     def send_triggers(self, marker):
         """Send timing triggers to recording device[s]"""

--- a/eegnb/experiments/Experiment.py
+++ b/eegnb/experiments/Experiment.py
@@ -130,7 +130,7 @@ class BaseExperiment(ABC):
         idx : Trial index of the most recently presented stimulus — same value that was
               passed to the preceding present_stimulus call.
         """
-        self.window.flip()
+        raise NotImplementedError
 
     def setup(self, instructions=True):
         # Setting up Graphics
@@ -299,6 +299,7 @@ class BaseExperiment(ABC):
         current_trial = trial_end_time = -1
         trial_start_time = None
         rendering_trial = -1
+        has_soa_override = type(self).present_soa is not BaseExperiment.present_soa
         
         # Clear/reset user input buffer
         self._clear_user_input()
@@ -322,9 +323,9 @@ class BaseExperiment(ABC):
                     # Stimulus presentation overwritten by specific experiment
                     self._draw(lambda: self.present_stimulus(current_trial))
                     rendering_trial = current_trial
-                else:
+                elif has_soa_override:
                     # Keep submitting frames during SOA wait — VR compositor
-                    # drops to half-rate if we stall between reversals.
+                    # drops to lower framerate if we stall between reversals.
                     self._draw(lambda: self.present_soa(current_trial))
             else:
                 self._draw(lambda: self.present_iti())

--- a/eegnb/experiments/__init__.py
+++ b/eegnb/experiments/__init__.py
@@ -1,19 +1,19 @@
-class MissingExperiment:
-    def __init__(self, *args, **kwargs):
-        raise RuntimeError(
-            "PsychoPy is not installed. Stimulus presentation experiments "
-            "are not available in this environment. Please install the "
-            "'stimpres' or 'full' dependencies to use this feature."
-        )
+from eegnb.utils.missing import missing_class
+
+MissingExperiment = missing_class(
+    "PsychoPy",
+    "Stimulus presentation experiments",
+    "stimpres",
+)
 
 try:
     from .visual_n170.n170 import VisualN170
     from .visual_p300.p300 import VisualP300
     from .visual_ssvep.ssvep import VisualSSVEP
 except ImportError:
-    VisualN170 = MissingExperiment  # type: ignore
-    VisualP300 = MissingExperiment  # type: ignore
-    VisualSSVEP = MissingExperiment  # type: ignore
+    VisualN170 = MissingExperiment
+    VisualP300 = MissingExperiment
+    VisualSSVEP = MissingExperiment
 
 try:
     from psychopy import sound, plugins, prefs
@@ -53,4 +53,4 @@ except ImportError:
 try:
     from .auditory_oddball.aob import AuditoryOddball
 except ImportError:
-    AuditoryOddball = MissingExperiment  # type: ignore
+    AuditoryOddball = MissingExperiment

--- a/eegnb/experiments/__init__.py
+++ b/eegnb/experiments/__init__.py
@@ -1,11 +1,19 @@
+class MissingExperiment:
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError(
+            "PsychoPy is not installed. Stimulus presentation experiments "
+            "are not available in this environment. Please install the "
+            "'stimpres' or 'full' dependencies to use this feature."
+        )
+
 try:
     from .visual_n170.n170 import VisualN170
     from .visual_p300.p300 import VisualP300
     from .visual_ssvep.ssvep import VisualSSVEP
 except ImportError:
-    VisualN170 = None  # type: ignore
-    VisualP300 = None  # type: ignore
-    VisualSSVEP = None  # type: ignore
+    VisualN170 = MissingExperiment  # type: ignore
+    VisualP300 = MissingExperiment  # type: ignore
+    VisualSSVEP = MissingExperiment  # type: ignore
 
 try:
     from psychopy import sound, plugins, prefs
@@ -45,4 +53,4 @@ except ImportError:
 try:
     from .auditory_oddball.aob import AuditoryOddball
 except ImportError:
-    AuditoryOddball = None  # type: ignore
+    AuditoryOddball = MissingExperiment  # type: ignore

--- a/eegnb/experiments/__init__.py
+++ b/eegnb/experiments/__init__.py
@@ -1,27 +1,48 @@
-from .visual_n170.n170 import VisualN170
-from .visual_p300.p300 import VisualP300
-from .visual_ssvep.ssvep import VisualSSVEP
+try:
+    from .visual_n170.n170 import VisualN170
+    from .visual_p300.p300 import VisualP300
+    from .visual_ssvep.ssvep import VisualSSVEP
+except ImportError:
+    VisualN170 = None  # type: ignore
+    VisualP300 = None  # type: ignore
+    VisualSSVEP = None  # type: ignore
 
-from psychopy import sound, plugins, prefs
-import platform
+try:
+    from psychopy import sound, plugins, prefs
+    import platform
+    import logging
 
-# PTB does not yet support macOS Apple Silicon freely, need to fall back to sounddevice.
-if platform.system() == 'Darwin' and platform.machine() == 'arm64':
-    # import psychopy_sounddevice.backend_sounddevice
-    plugins.scanPlugins()
-    success = plugins.loadPlugin('psychopy-sounddevice')
-    print(f"psychopy_sounddevice plugin loaded: {success}")
+    # PTB does not yet support macOS Apple Silicon freely, need to fall back to sounddevice.
+    if platform.system() == 'Darwin' and platform.machine() == 'arm64':
+        # import psychopy_sounddevice.backend_sounddevice
+        plugins.scanPlugins()
+        success = plugins.loadPlugin('psychopy-sounddevice')
+        print(f"psychopy_sounddevice plugin loaded: {success}")
 
-    # Force reload sound module
-    import importlib
-    importlib.reload(sound)
-    # setting prefs.hardware['audio_device'] still falls back to a default device, need to use setDevice.
-    audio_device = prefs.hardware.get('audioDevice', 'default')
-    if audio_device and audio_device != 'default':
-        sound.setDevice(audio_device)
-else:
-    #change the pref library to PTB and set the latency mode to high precision
-    prefs.hardware['audioLib'] = 'PTB'
-    prefs.hardware['audioLatencyMode'] = 3
+        # Force reload sound module
+        import importlib
+        importlib.reload(sound)
+        
+        # Try to set the audio device if requested and available
+        audio_device = prefs.hardware.get('audioDevice', 'default')
+        if audio_device and audio_device != 'default':
+            if hasattr(sound, 'setDevice'):
+                try:
+                    sound.setDevice(audio_device)
+                except Exception as e:
+                    logging.warning(f"Failed to set audio device to '{audio_device}': {e}")
+            else:
+                logging.warning(f"sound.setDevice not available, could not set device to '{audio_device}'")
+    else:
+        #change the pref library to PTB and set the latency mode to high precision
+        prefs.hardware['audioLib'] = 'PTB'
+        prefs.hardware['audioLatencyMode'] = 3
+except ImportError:
+    import logging
+    # logging.warning("PsychoPy not found. Stimulus presentation experiments will not be available.")
+    pass
 
-from .auditory_oddball.aob import AuditoryOddball
+try:
+    from .auditory_oddball.aob import AuditoryOddball
+except ImportError:
+    AuditoryOddball = None  # type: ignore

--- a/eegnb/experiments/__init__.py
+++ b/eegnb/experiments/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from eegnb.utils.missing import missing_class
 
 MissingExperiment = missing_class(
@@ -6,14 +8,19 @@ MissingExperiment = missing_class(
     "stimpres",
 )
 
-try:
+if TYPE_CHECKING:
     from .visual_n170.n170 import VisualN170
     from .visual_p300.p300 import VisualP300
     from .visual_ssvep.ssvep import VisualSSVEP
-except ImportError:
-    VisualN170 = MissingExperiment
-    VisualP300 = MissingExperiment
-    VisualSSVEP = MissingExperiment
+else:
+    try:
+        from .visual_n170.n170 import VisualN170
+        from .visual_p300.p300 import VisualP300
+        from .visual_ssvep.ssvep import VisualSSVEP
+    except ImportError:
+        VisualN170 = MissingExperiment
+        VisualP300 = MissingExperiment
+        VisualSSVEP = MissingExperiment
 
 try:
     from psychopy import sound, plugins, prefs
@@ -50,7 +57,10 @@ except ImportError:
     # logging.warning("PsychoPy not found. Stimulus presentation experiments will not be available.")
     pass
 
-try:
+if TYPE_CHECKING:
     from .auditory_oddball.aob import AuditoryOddball
-except ImportError:
-    AuditoryOddball = MissingExperiment
+else:
+    try:
+        from .auditory_oddball.aob import AuditoryOddball
+    except ImportError:
+        AuditoryOddball = MissingExperiment

--- a/eegnb/utils/missing.py
+++ b/eegnb/utils/missing.py
@@ -1,0 +1,56 @@
+"""Sentinel objects for optional dependencies.
+
+Lets the package import cleanly even when an optional library isn't installed,
+while still raising a clear, actionable error if a user tries to use a feature
+that depends on it.
+
+Two flavours:
+    missing_class(...)   — for symbols the user *instantiates* (e.g. an
+                            Experiment subclass). Raises on construction.
+    missing_module(...)  — for symbols the user *accesses attributes on*
+                            (e.g. ``pyxid2.get_xid_devices()``). Raises on
+                            any attribute access.
+"""
+
+
+from typing import Any
+
+
+def _format_message(name: str, feature: str, extras: str) -> str:
+    return (
+        f"{name} is not installed. {feature} is not available in this "
+        f"environment. Please install the '{extras}' or 'full' dependencies "
+        "to use this feature."
+    )
+
+
+def missing_class(name: str, feature: str, extras: str) -> Any:
+    """Sentinel mimicking a class; raises RuntimeError on instantiation.
+
+    Returns ``Any`` so the sentinel can be assigned to a name that would
+    normally hold a specific class (e.g. ``VisualN170 = missing_class(...)``)
+    without type-checker complaints at the call site.
+    """
+    message = _format_message(name, feature, extras)
+
+    class _Missing:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(message)
+
+    return _Missing
+
+
+def missing_module(name: str, feature: str, extras: str) -> Any:
+    """Sentinel mimicking a module; raises RuntimeError on attribute access.
+
+    Returns ``Any`` so the sentinel can be assigned to a name that would
+    normally hold a real module (e.g. ``pyxid2 = missing_module(...)``)
+    without type-checker complaints at the call site.
+    """
+    message = _format_message(name, feature, extras)
+
+    class _Missing:
+        def __getattr__(self, attr):
+            raise RuntimeError(message)
+
+    return _Missing()

--- a/environments/eeg-expy-docsbuild.yml
+++ b/environments/eeg-expy-docsbuild.yml
@@ -3,7 +3,8 @@ channels:
     - defaults
 dependencies:
     # System-level dependencies
-    - python>=3.8,<=3.13
+    - python >=3.10 # higher versions allowed for experimental builds
+    - setuptools
     - pytables # install pytables for macOS arm64, so do not need to build from source.
     - rust # used by docsbuild
     - pip

--- a/environments/eeg-expy-full.yml
+++ b/environments/eeg-expy-full.yml
@@ -3,7 +3,8 @@ channels:
     - defaults
 dependencies:
     # System-level dependencies
-    - python>=3.8,<=3.10 # psychopy <= 3.10
+    - python>=3.10,<=3.11 # psychopy 2026.x requires py3.10; higher versions for experimental builds
+    - setuptools
     - dukpy==0.2.3 # psychopy dependency, avoid failing due to building wheel on win 3.9.
     - numpy # fix PsychXR numpy dependency DLL issues on Windows
     - pytables # install pytables for macOS arm64, so do not need to build from source.

--- a/environments/eeg-expy-stimpres.yml
+++ b/environments/eeg-expy-stimpres.yml
@@ -3,7 +3,8 @@ channels:
     - defaults
 dependencies:
     # System-level dependencies
-    - python>=3.8,<=3.10 # psychopy <= 3.10
+    - python >=3.10 # psychopy 2026.x requires py3.10; higher versions allowed for experimental builds
+    - setuptools
     - dukpy==0.2.3 # psychopy dependency, avoid failing due to building wheel on win 3.9.
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"
     - cffi # Fix sound ffi.callback() issue with sounddevice on macOS: https://github.com/spatialaudio/python-sounddevice/issues/397

--- a/environments/eeg-expy-streaming.yml
+++ b/environments/eeg-expy-streaming.yml
@@ -3,7 +3,8 @@ channels:
     - defaults
 dependencies:
     # System-level dependencies
-    - python>=3.8,<=3.13
+    - python >=3.10 # higher versions allowed for experimental builds
+    - setuptools
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - pip
     - pip:

--- a/environments/eeg-expy-streamstim.yml
+++ b/environments/eeg-expy-streamstim.yml
@@ -3,7 +3,8 @@ channels:
     - defaults
 dependencies:
     # System-level dependencies
-    - python>=3.8,<=3.10 # psychopy <= 3.10
+    - python>=3.10,<=3.13 # psychopy <= 3.10; higher versions for experimental builds
+    - setuptools
     - dukpy==0.2.3 # psychopy dependency, avoid failing due to building wheel on win 3.9.
     - liblsl # install liblsl to prevent error on macOS and Ubuntu: "RuntimeError: LSL binary library file was not found."
     - wxpython>=4.0 # install wxpython to prevent error on macOS arm64: "site-packages/wx/_core.cpython-38-darwin.so, 0x0002): symbol not found in flat namespace '__ZN10wxBoxSizer20InformFirstDirectionEiii'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ addopts = """
     --current-env
     --ignore-glob 'examples/**.py'
     --ignore-glob '**/baseline_task.py'
+    --ignore 'tests/test_run_experiments.py'
 """
 testpaths = [
     "eegnb",

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ pysocks>=1.7.1
 pyserial>=3.5
 h5py>=3.1.0
 pytest-shutil
-pyo>=1.0.3; platform_system == "Linux"
+
 airium>=0.1.0
 attrdict>=2.0.1
 attrdict3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,7 @@
 
 scikit-learn>=0.23.2
 pandas>=1.1.4
-numpy>=1.26.0;  python_version >= "3.9"
-numpy<=1.24.4; python_version == "3.8"
+numpy>=1.26.0
 mne>=0.20.8
 seaborn>=0.11.0
 pyriemann>=0.2.7
@@ -15,10 +14,7 @@ pysocks>=1.7.1
 pyserial>=3.5
 h5py>=3.1.0
 pytest-shutil
-pyo>=1.0.3; platform_system == "Linux"
-#pynput requires pyobjc, psychopy requires a version less than 8, setting pyobjc to
-# a specific version prevents an endless dependency resolution loop.
-pyobjc==7.3; sys_platform == 'darwin'
+pyobjc>=8.0; sys_platform == 'darwin'
 airium>=0.1.0
 attrdict>=2.0.1
 attrdict3
@@ -26,6 +22,7 @@ attrdict3
 
 ## ~~ Streaming Requirements ~~ 
 
+pyxid2
 muselsl>=2.0.2
 # Upgrade from 1.10.5 to 1.16.2 so the arm64 lib is available to macOS Apple Silicon for preventing error:
 # pylsl/liblsl64.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
@@ -35,10 +32,7 @@ pysocks>=1.7.1
 pyserial>=3.5
 h5py>=3.1.0
 pytest-shutil
-pyo>=1.0.3; platform_system == "Linux"
-#pynput requires pyobjc, psychopy requires a version less than 8, setting pyobjc to
-# a specific version prevents an endless dependency resolution loop.
-pyobjc==7.3; sys_platform == 'darwin'
+pyobjc>=8.0; sys_platform == 'darwin'
 #Removed keyboard dependency due segmentation fault on Apple Silicon: https://github.com/boppreh/keyboard/issues/507
 pynput
 airium>=0.1.0
@@ -46,22 +40,25 @@ attrdict>=2.0.1
 attrdict3
 click
 
+# Tests
+pytest
+pytest-cov
+nbval
+
 
 ## ~~ Stimpres Requirements ~~ 
 
-#pynput requires pyobjc, psychopy requires a version less than 8, setting pyobjc to
-# a specific version prevents an endless dependency resolution loop.
-pyobjc==7.3; sys_platform == 'darwin'
+pyobjc>=8.0; sys_platform == 'darwin'
 #upgrade psychopy to use newer wxpython dependency which is prebuilt for m1 support.
-psychopy==2025.1.1
-#needed for macos arm sound support: https://github.com/psychopy/psychopy-sounddevice/pull/4
--e psychopy-sounddevice
+# Forked with a fix for Rift stereo projection matrix crash under strict-ndim psychxr.
+psychopy @ git+https://github.com/pellet/psychopy.git@v2026.2.0-rift-fix
+#needed for macos arm sound support
+psychopy-sounddevice @ git+https://github.com/psychopy/psychopy-sounddevice.git
 ffpyplayer==4.5.2 # 4.5.3 fails to build as wheel.
 psychtoolbox
 scikit-learn>=0.23.2
 pandas>=1.1.4
-numpy>=1.26.0;  python_version >= "3.9"
-numpy==1.24.4; python_version == "3.8"
+numpy>=1.26.0
 mne>=0.20.8
 seaborn>=0.11.0
 pysocks>=1.7.1
@@ -73,23 +70,23 @@ airium>=0.1.0
 attrdict>=2.0.1
 attrdict3
 
-# pywinhook needs some special treatment since there are only wheels on PyPI for Python 3.7-3.8, and building requires special tools (swig, VS C++ tools)
-# See issue: https://github.com/NeuroTechX/eeg-notebooks/issues/29
-pywinhook>=1.6.0 ; platform_system == "Windows" and (python_version == "3.7" or python_version == "3.8")
-pywinhook @ https://github.com/ActivityWatch/wheels/raw/master/pywinhook/pyWinhook-1.6.2-cp39-cp39-win_amd64.whl ; platform_system == "Windows" and python_version == "3.9"
-
 # pyglet downgrade to prevent threadmode warning on windows
 # See issue: https://github.com/psychopy/psychopy/issues/2876
 pyglet==1.4.11 ; platform_system == "Windows"
 
-# Oculus/Quest VR support - currently only supported on Windows and
-# <= 3.9, otherwise will need Oculus PC SDK to build wheel.
-psychxr>=0.2.4rc2; platform_system == "Windows" and python_version <= "3.9"
+# Quest-link VR support - prebuilt Windows wheels from the fork's GitHub
+# release (0.2.6rc1 adds Python 3.10 support).
+# psychxr/quest-link is Windows-only.
+psychxr @ https://github.com/pellet/psychxr/releases/download/v0.2.6rc1/psychxr-0.2.6rc1-cp310-cp310-win_amd64.whl ; platform_system == "Windows" and python_version == "3.10"
+
+# PsychoPy/PsychXR does not yet officially support Python > 3.10; the wheels below are experimental.
+psychxr @ https://github.com/pellet/psychxr/releases/download/v0.2.6rc1/psychxr-0.2.6rc1-cp311-cp311-win_amd64.whl ; platform_system == "Windows" and python_version == "3.11"
+psychxr @ https://github.com/pellet/psychxr/releases/download/v0.2.6rc1/psychxr-0.2.6rc1-cp312-cp312-win_amd64.whl ; platform_system == "Windows" and python_version == "3.12"
+psychxr @ https://github.com/pellet/psychxr/releases/download/v0.2.6rc1/psychxr-0.2.6rc1-cp313-cp313-win_amd64.whl ; platform_system == "Windows" and python_version == "3.13"
 
 
-
-
-## ~~ Docsbuild Requirements ~~ 
+## ~~ Docsbuild Requirements ~~
+setuptools<81  # brainflow imports pkg_resources at runtime; setuptools 81 deprecated it and 82 removed it
 recommonmark
 brainflow
 numpydoc

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,0 +1,56 @@
+import os
+import time
+import pandas as pd
+import pytest
+from eegnb.devices.eeg import EEG
+
+def test_synthetic_acquisition(tmp_path):
+    """
+    Test the data acquisition pipeline using a synthetic BrainFlow board.
+    This verifies that we can initialize a device, start a stream, 
+    record data, and save it to a CSV file in a CI-friendly way.
+    """
+    # Use a temporary file for recording
+    save_fn = tmp_path / "synthetic_data.csv"
+    
+    # Initialize EEG with synthetic board
+    # BrainFlow synthetic board (ID -1) works without hardware
+    eeg = EEG(device='synthetic')
+    
+    # Verify metadata initialization
+    assert eeg.backend == 'brainflow'
+    assert eeg.sfreq == 250  # Default for synthetic board
+    assert len(eeg.channels) > 0
+    
+    # Start stream and capture data
+    # We specify a short duration for the test
+    record_duration = 2
+    eeg.start(str(save_fn), duration=record_duration + 5)
+    
+    # Simulate some experiment time
+    time.sleep(record_duration)
+    
+    # Push a few synthetic markers
+    eeg.push_sample(marker=1, timestamp=time.time())
+    time.sleep(0.1)
+    eeg.push_sample(marker=2, timestamp=time.time())
+    
+    # Stop recording and release session
+    eeg.stop()
+    
+    # Verify file creation and content
+    assert save_fn.exists()
+    
+    # Read the data back
+    data = pd.read_csv(save_fn)
+    
+    # Basic data validation
+    assert len(data) > 0
+    assert 'timestamps' in data.columns
+    assert 'stim' in data.columns
+    
+    # Check if markers were recorded (may vary slightly based on timing)
+    # but we should at least see non-zero values in the stim column
+    assert (data['stim'] != 0).any()
+    
+    print(f"Acquired {len(data)} samples with columns: {list(data.columns)}")


### PR DESCRIPTION
build / CI:
* CI matrix expanded — default Python 3.10 (was 3.8); experimental jobs on py3.11 (full env), py3.12 / py3.13 (streaming env).
* dropped support for Python 3.8 and 3.9 across all conda envs and requirements.
* matrix now parameterized by env_file / env_name so streaming-only builds can run without psychopy/psychxr.
* typecheck job moved from py3.9 to py3.10.

dependencies:
* psychopy bumped to fork pellet/psychopy@v2026.2.0-rift-fix — fixes Rift stereo projection-matrix crash under strict-ndim psychxr.
* psychopy-sounddevice switched from local editable install to official upstream Git tip (handles macOS arm64 sound).
* psychxr — prebuilt Windows wheels from pellet/psychxr fork for cp310–cp313 (PyPI only ships 0.2.4 for ≤ py3.9). Adds experimental Quest-link VR support on py3.10–3.13.
* pyobjc bumped 7.3 → ≥8.0 for newer psychopy.
* pyxid2 added to streaming requirements.
* pywinhook removed — obsolete once py3.9 was dropped (modern pynput on py3.10+ doesn't need it).
* pyo completely removed from dependencies (audio was never needed for Analysis/Streaming, and fails to build on py3.11).
* numpy py3.8 pin removed (numpy>=1.26 across the board).
* setuptools<81 pinned in docsbuild reqs — brainflow imports pkg_resources at runtime, which setuptools 81 deprecated and 82 removed.
* test deps (pytest, pytest-cov, nbval) moved into streaming requirements so streaming-only CI can run them.

streaming env decoupling:
* new eegnb/devices/vr.py with class VR — encapsulates psychxr/Rift integration (clock sync, per-trial telemetry buffering, telemetry CSV save, optical-axis offset computation) behind a generic VR-device name. Imported lazily so the streaming-only conda env (no psychxr) can still use the package.
* lazy/optional imports added in eegnb/cli/utils.py, eegnb/cli/introprompt.py, eegnb/experiments/__init__.py so the package can be imported under a streaming-only env (no VR / no sound libs).
* new tests/test_acquisition.py (acquisition smoke test) — what the streaming-env CI job actually runs.
* new conftest.py for shared pytest setup.
* eegnb/devices/eeg.py — `import pyxid2` wrapped in try/except so users without a Cedrus FTDI driver don't crash at import time.

experiment runtime:
* per-eye stimulus alignment now queried from the HMD runtime instead of being hard-coded to ±0.2. Quest 2/3 lenses are angled inward and offset within their own image, so a single fixed value left the checkerboard slightly off-centre and looking tilted outward. The new compute_optical_axis_offsets() asks the runtime for the actual per-lens position so the stimulus sits where each eye is naturally looking.
* trial loop now runs at higher OS scheduling priority (psychopy core.rush) with Python's garbage collector paused, so the GC can't pause stimulus rendering mid-trial.
* HMD-clock to system-clock sync moved into a single VR.sync_vr_clock() call at the start of each run, so per-trial telemetry timestamps line up with EEG markers.